### PR TITLE
Handle uppercase query params

### DIFF
--- a/src/hexdeck.gleam
+++ b/src/hexdeck.gleam
@@ -216,6 +216,7 @@ fn view_embed_wrapper(
               ]),
               html.input([
                 attribute.class("bg-transparent flex-1"),
+                attribute.attribute("autocapitalize", "off"),
                 attribute.value(src),
               ]),
             ],

--- a/src/hexdeck.gleam
+++ b/src/hexdeck.gleam
@@ -133,7 +133,7 @@ fn update_query(order: List(Int), frames: Dict(Int, String)) -> Effect(msg) {
           list.filter_map(order, fn(key) {
             frames
             |> dict.get(key)
-            |> result.try(fn(param) { Ok(string.lowercase(param)) })
+            |> result.map(string.lowercase)
             |> result.map(pair.new(int.to_string(key), _))
           }),
         )

--- a/src/hexdeck.gleam
+++ b/src/hexdeck.gleam
@@ -11,7 +11,7 @@ import gleam/result
 import gleam/string
 import gleam/uri
 import lustre
-import lustre/attribute.{type Attribute}
+import lustre/attribute.{type Attribute, attribute}
 import lustre/effect.{type Effect}
 import lustre/element.{type Element}
 import lustre/element/html
@@ -216,7 +216,7 @@ fn view_embed_wrapper(
               ]),
               html.input([
                 attribute.class("bg-transparent flex-1"),
-                attribute.attribute("autocapitalize", "off"),
+                attribute("autocapitalize", "off"),
                 attribute.value(src),
               ]),
             ],

--- a/src/hexdeck.gleam
+++ b/src/hexdeck.gleam
@@ -8,6 +8,7 @@ import gleam/list
 import gleam/option.{type Option}
 import gleam/pair
 import gleam/result
+import gleam/string
 import gleam/uri
 import lustre
 import lustre/attribute.{type Attribute}
@@ -132,6 +133,7 @@ fn update_query(order: List(Int), frames: Dict(Int, String)) -> Effect(msg) {
           list.filter_map(order, fn(key) {
             frames
             |> dict.get(key)
+            |> result.try(fn(param) { Ok(string.lowercase(param)) })
             |> result.map(pair.new(int.to_string(key), _))
           }),
         )


### PR DESCRIPTION
Hey, i tried your demo on https://hexdeck.pm on an iOS device and by default, the first character in an input field is uppercase and it couldn't find the correct hexdocs page. This should fix it, setting the input to not capitalize and by forcing the query to lowercase in `update_query`.
This is my fist time writing Gleam, so if there's anything i could do better, i'm happy to reiterate!